### PR TITLE
feat: Update home page to display git commits

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -17,7 +17,7 @@ RUN sudo apt-get update && \
 
 # Install uv for Python package management
 RUN curl -LsSf https://astral.sh/uv/install.sh | sh && \
-    sudo mv /root/.cargo/bin/uv /usr/local/bin/uv
+    sudo mv /root/.local/bin/uv /usr/local/bin/uv
 
 # Install Hugo for Github Releases Page
 RUN mkdir -p /tmp/hugo && \

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -3,6 +3,21 @@ FROM mcr.microsoft.com/devcontainers/base:bookworm
 ARG BUILDARCH
 ARG HUGO_VERSION=0.131.0
 ARG NODE_VERSION=22
+ARG UV_VERSION=0.4.17
+
+# Install system dependencies
+RUN sudo apt-get update && \
+    sudo apt-get install -y \
+    curl \
+    git \
+    python3 \
+    python3-pip \
+    python3-venv \
+    && sudo rm -rf /var/lib/apt/lists/*
+
+# Install uv for Python package management
+RUN curl -LsSf https://astral.sh/uv/install.sh | sh && \
+    sudo mv /root/.cargo/bin/uv /usr/local/bin/uv
 
 # Install Hugo for Github Releases Page
 RUN mkdir -p /tmp/hugo && \

--- a/exampleSite/config.yaml
+++ b/exampleSite/config.yaml
@@ -27,6 +27,7 @@ params:
   # For more date formats see https://gohugo.io/functions/format/
   dateFormat: Jan 2, 2006
   navTitleLink: /
+  enable_search: true  # Enable search functionality
 
 menu:
   nav:
@@ -49,8 +50,17 @@ menu:
       url: /index.xml
       weight: 6
 
-markup:
-  defaultMarkdownHandler: goldmark
+outputs:
+  home:
+    - HTML
+    - SearchIndex
+
+outputFormats:
+  SearchIndex:
+    mediaType: application/json
+    baseName: search
+    isPlainText: true
+    notAlternative: true
   goldmark:
     extensions:
       definitionList: true

--- a/exampleSite/config.yaml
+++ b/exampleSite/config.yaml
@@ -28,6 +28,7 @@ params:
   dateFormat: Jan 2, 2006
   navTitleLink: /
   enable_search: true  # Enable search functionality
+  github_repo: "owner/repo"  # Used for commit links when the homepage shows git commits (see data/commits.json)
 
 menu:
   nav:

--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -9,5 +9,9 @@
         {{ block "main" . }}{{ end }}
       </main>
   </div>
+  {{ if site.Params.enable_search }}
+  <script src="https://cdn.jsdelivr.net/npm/fuse.js@7.0.0"></script>
+  <script src="/js/search.js"></script>
+  {{ end }}
   </body>
 </html>

--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -4,6 +4,7 @@
   <body>
     <div class="container paper">
       {{ partial "nav.html" . }}
+      {{ partial "searchbox.html" . }}
       <main>
         {{ block "main" . }}{{ end }}
       </main>

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -3,8 +3,8 @@
 <h1>{{ .Title }}</h1>
 {{ .Content }}
 
-{{ with site.Data.commits }}
-  {{ $commits := . }}
+{{ if site.Data.commits }}
+  {{ $commits := site.Data.commits }}
   {{ $totalCommits := len $commits }}
   
   <div id="commits-container">
@@ -44,11 +44,6 @@
         // Build GitHub commit URL dynamically from config
         const commitUrl = githubRepo ? 
           `https://github.com/${githubRepo}/commit/${commit.full_hash}` : 
-          '#';
-        
-        // Build GitHub commits list URL
-        const commitsListUrl = githubRepo ? 
-          `https://github.com/${githubRepo}/commits/main` : 
           '#';
         
         html += `
@@ -135,9 +130,20 @@
   </script>
   
 {{ else }}
-  <p style="color: #666; font-style: italic;">
-    No commit data available. Please run <code>make generate-commits</code> to generate commit data.
-  </p>
+  {{/* Fallback: Show regular content (blog posts or _index.md content) */}}
+  {{ $paginator := .Paginate (where site.RegularPages "Type" "in" site.Params.mainSections) }}
+  
+  {{ range $paginator.Pages.ByPublishDate.Reverse }}
+    <h2 class="post-list {{ if ne .Params.show_summary false }}summary{{ end }}">
+      <a href="{{ .RelPermalink }}">
+        {{ .Title }}
+      </a>
+    </h2>
+    {{ if ne .Params.show_summary false }}
+      {{ .Summary }}
+    {{ end }}
+  {{ end }}
+  {{ template "partials/pagination.html" . }}
 {{ end }}
 
 {{ end }}

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -76,13 +76,15 @@
                 <ul style="list-style: none; padding-left: 0; margin-top: 0.5rem;">
                   ${commit.changed_files_mapped.map(file => `
                     <li style="margin-bottom: 0.3rem;">
+                      <span style="margin-right: 0.5rem;" title="${file.status_info.label}">${file.status_info.icon}</span>
                       ${file.type === 'page' ? `
-                        <a href="${file.url}" style="text-decoration: none;">📄 ${file.file_path}</a>
+                        <a href="${file.url}" style="text-decoration: none;">${file.file_path}</a>
                       ` : file.type === 'section' ? `
-                        <a href="${file.url}" style="text-decoration: none;">📁 ${file.file_path}</a>
+                        <a href="${file.url}" style="text-decoration: none;">${file.file_path}</a>
                       ` : `
-                        <a href="${file.url}" style="text-decoration: none;" target="_blank" rel="noopener">🔗 ${file.file_path} (GitHub)</a>
+                        <a href="${file.url}" style="text-decoration: none;" target="_blank" rel="noopener">${file.file_path} (GitHub)</a>
                       `}
+                      <span style="color: #999; font-size: 0.85rem; margin-left: 0.5rem;">${file.status_info.label}</span>
                     </li>
                   `).join('')}
                 </ul>

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -78,11 +78,11 @@
                     <li style="margin-bottom: 0.3rem;">
                       <span style="margin-right: 0.5rem;" title="${file.status_info.label}">${file.status_info.icon}</span>
                       ${file.type === 'page' ? `
-                        <a href="${file.url}" style="text-decoration: none;">${file.file_path}</a>
+                        <a href="${file.url}" style="text-decoration: none;">${file.path}</a>
                       ` : file.type === 'section' ? `
-                        <a href="${file.url}" style="text-decoration: none;">${file.file_path}</a>
+                        <a href="${file.url}" style="text-decoration: none;">${file.path}</a>
                       ` : `
-                        <a href="${file.url}" style="text-decoration: none;" target="_blank" rel="noopener">${file.file_path} (GitHub)</a>
+                        <a href="${file.url}" style="text-decoration: none;" target="_blank" rel="noopener">${file.path} (GitHub)</a>
                       `}
                       <span style="color: #999; font-size: 0.85rem; margin-left: 0.5rem;">${file.status_info.label}</span>
                     </li>

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -78,11 +78,11 @@
                     <li style="margin-bottom: 0.3rem;">
                       <span style="margin-right: 0.5rem;" title="${file.status_info.label}">${file.status_info.icon}</span>
                       ${file.type === 'page' ? `
-                        <a href="${file.url}" style="text-decoration: none;">${file.path}</a>
+                        <a href="${file.url}" style="text-decoration: none;">${file.file_path}</a>
                       ` : file.type === 'section' ? `
-                        <a href="${file.url}" style="text-decoration: none;">${file.path}</a>
+                        <a href="${file.url}" style="text-decoration: none;">${file.file_path}</a>
                       ` : `
-                        <a href="${file.url}" style="text-decoration: none;" target="_blank" rel="noopener">${file.path} (GitHub)</a>
+                        <a href="${file.url}" style="text-decoration: none;" target="_blank" rel="noopener">${file.file_path} (GitHub)</a>
                       `}
                       <span style="color: #999; font-size: 0.85rem; margin-left: 0.5rem;">${file.status_info.label}</span>
                     </li>

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -5,8 +5,7 @@
 
 {{ if site.Data.commits }}
   {{ $commits := site.Data.commits }}
-  {{ $totalCommits := len $commits }}
-  
+
   <div id="commits-container">
     <div id="commits-list"></div>
     

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -29,6 +29,9 @@
     const commitsPerPage = 10;
     let currentPage = 1;
     
+    // Get GitHub repo from Hugo config (set in site's config.yaml)
+    const githubRepo = {{ site.Params.github_repo | default "" | jsonify | safeJS }};
+    
     function renderCommits() {
       const container = document.getElementById('commits-list');
       const startIndex = (currentPage - 1) * commitsPerPage;
@@ -38,10 +41,20 @@
       let html = '';
       
       pageCommits.forEach(commit => {
+        // Build GitHub commit URL dynamically from config
+        const commitUrl = githubRepo ? 
+          `https://github.com/${githubRepo}/commit/${commit.full_hash}` : 
+          '#';
+        
+        // Build GitHub commits list URL
+        const commitsListUrl = githubRepo ? 
+          `https://github.com/${githubRepo}/commits/main` : 
+          '#';
+        
         html += `
           <article class="commit-entry" style="margin-bottom: 2rem; padding-bottom: 2rem; border-bottom: 1px solid #eee;">
             <h2 style="margin-bottom: 0.5rem;">
-              <a href="https://github.com/ssmiller25/r15cookie-site/commit/${commit.full_hash}" 
+              <a href="${commitUrl}" 
                  style="text-decoration: none; color: inherit;"
                  target="_blank" rel="noopener">
                 ${commit.subject}
@@ -60,7 +73,7 @@
               </span>
             </div>
             
-            ${commit.body ? `<div class="commit-body" style="margin: 1rem 0;">${commit.body.replace(/\n/g, '<br>')}</div>` : ''}
+            ${commit.body ? `<div class="commit-body" style="margin: 1rem 0;">${commit.body.replace(/\\n/g, '<br>')}</div>` : ''}
             
             ${commit.changed_files_mapped && commit.changed_files_mapped.length > 0 ? `
               <div class="commit-files" style="margin-top: 1rem;">

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -2,17 +2,81 @@
 
 <h1>{{ .Title }}</h1>
 {{ .Content }}
-{{ $paginator := .Paginate (where site.RegularPages "Type" "in" site.Params.mainSections) }}
 
-{{ range $paginator.Pages.ByPublishDate.Reverse }}
-  <h2 class="post-list {{ if ne .Params.show_summary false }}summary{{ end }}">
-    <a href="{{ .RelPermalink }}">
-      {{ .Title }}
-    </a>
-  </h2>
-  {{ if ne .Params.show_summary false }}
-    {{ .Summary }}
+{{ with site.Data.commits }}
+  {{ $commits := . }}
+  {{ $totalCommits := len $commits }}
+  
+  {{/* Show last 10 commits */}}
+  {{ $recentCommits := first 10 $commits }}
+  
+  {{ range $index, $commit := $recentCommits }}
+    <article class="commit-entry" style="margin-bottom: 2rem; padding-bottom: 2rem; border-bottom: 1px solid #eee;">
+      <h2 style="margin-bottom: 0.5rem;">
+        <a href="https://github.com/ssmiller25/r15cookie-site/commit/{{ $commit.full_hash }}" 
+           style="text-decoration: none; color: inherit;"
+           target="_blank" rel="noopener">
+          {{ $commit.subject }}
+        </a>
+      </h2>
+      
+      <div class="commit-meta" style="color: #666; font-size: 0.9rem; margin-bottom: 1rem;">
+        <span class="commit-hash" style="font-family: monospace; background: #f4f4f4; padding: 2px 6px; border-radius: 3px;">
+          {{ $commit.short_hash }}
+        </span>
+        <span class="commit-date" style="margin-left: 1rem;">
+          {{ $commit.date }}
+        </span>
+        <span class="commit-author" style="margin-left: 1rem;">
+          by {{ $commit.author_name }}
+        </span>
+      </div>
+      
+      {{ if $commit.body }}
+        <div class="commit-body" style="margin: 1rem 0;">
+          {{ $commit.body | markdownify }}
+        </div>
+      {{ end }}
+      
+      {{ if $commit.changed_files_mapped }}
+        <div class="commit-files" style="margin-top: 1rem;">
+          <strong>Changed files:</strong>
+          <ul style="list-style: none; padding-left: 0; margin-top: 0.5rem;">
+            {{ range $file := $commit.changed_files_mapped }}
+              <li style="margin-bottom: 0.3rem;">
+                {{ if eq $file.type "page" }}
+                  <a href="{{ $file.url }}" style="text-decoration: none;">
+                    📄 {{ $file.file_path }}
+                  </a>
+                {{ else if eq $file.type "section" }}
+                  <a href="{{ $file.url }}" style="text-decoration: none;">
+                    📁 {{ $file.file_path }}
+                  </a>
+                {{ else }}
+                  <a href="{{ $file.url }}" style="text-decoration: none;" target="_blank" rel="noopener">
+                    🔗 {{ $file.file_path }} (GitHub)
+                  </a>
+                {{ end }}
+              </li>
+            {{ end }}
+          </ul>
+        </div>
+      {{ end }}
+    </article>
   {{ end }}
+  
+  {{ if gt $totalCommits 10 }}
+    <p style="margin-top: 2rem; color: #666;">
+      Showing last 10 commits. 
+      <a href="https://github.com/ssmiller25/r15cookie-site/commits/main" target="_blank" rel="noopener">
+        View all {{ $totalCommits }} commits on GitHub →
+      </a>
+    </p>
+  {{ end }}
+{{ else }}
+  <p style="color: #666; font-style: italic;">
+    No commit data available. Please run <code>make generate-commits</code> to generate commit data.
+  </p>
 {{ end }}
-{{ template "partials/pagination.html" . }}
+
 {{ end }}

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -7,72 +7,120 @@
   {{ $commits := . }}
   {{ $totalCommits := len $commits }}
   
-  {{/* Show last 10 commits */}}
-  {{ $recentCommits := first 10 $commits }}
+  <div id="commits-container">
+    <div id="commits-list"></div>
+    
+    <nav id="pagination-nav" style="margin-top: 2rem; text-align: center; display: none;">
+      <button id="prev-page" style="margin: 0 0.5rem; padding: 0.5rem 1rem; border: 1px solid #ddd; background: white; cursor: pointer; border-radius: 3px;">
+        ← Newer
+      </button>
+      
+      <span id="page-info" style="margin: 0 1rem;"></span>
+      
+      <button id="next-page" style="margin: 0 0.5rem; padding: 0.5rem 1rem; border: 1px solid #ddd; background: white; cursor: pointer; border-radius: 3px;">
+        Older →
+      </button>
+    </nav>
+  </div>
   
-  {{ range $index, $commit := $recentCommits }}
-    <article class="commit-entry" style="margin-bottom: 2rem; padding-bottom: 2rem; border-bottom: 1px solid #eee;">
-      <h2 style="margin-bottom: 0.5rem;">
-        <a href="https://github.com/ssmiller25/r15cookie-site/commit/{{ $commit.full_hash }}" 
-           style="text-decoration: none; color: inherit;"
-           target="_blank" rel="noopener">
-          {{ $commit.subject }}
-        </a>
-      </h2>
+  <script>
+    // Embed commits data
+    const commitsData = {{ $commits | jsonify | safeJS }};
+    const commitsPerPage = 10;
+    let currentPage = 1;
+    
+    function renderCommits() {
+      const container = document.getElementById('commits-list');
+      const startIndex = (currentPage - 1) * commitsPerPage;
+      const endIndex = Math.min(startIndex + commitsPerPage, commitsData.length);
+      const pageCommits = commitsData.slice(startIndex, endIndex);
       
-      <div class="commit-meta" style="color: #666; font-size: 0.9rem; margin-bottom: 1rem;">
-        <span class="commit-hash" style="font-family: monospace; background: #f4f4f4; padding: 2px 6px; border-radius: 3px;">
-          {{ $commit.short_hash }}
-        </span>
-        <span class="commit-date" style="margin-left: 1rem;">
-          {{ $commit.date }}
-        </span>
-        <span class="commit-author" style="margin-left: 1rem;">
-          by {{ $commit.author_name }}
-        </span>
-      </div>
+      let html = '';
       
-      {{ if $commit.body }}
-        <div class="commit-body" style="margin: 1rem 0;">
-          {{ $commit.body | markdownify }}
-        </div>
-      {{ end }}
+      pageCommits.forEach(commit => {
+        html += `
+          <article class="commit-entry" style="margin-bottom: 2rem; padding-bottom: 2rem; border-bottom: 1px solid #eee;">
+            <h2 style="margin-bottom: 0.5rem;">
+              <a href="https://github.com/ssmiller25/r15cookie-site/commit/${commit.full_hash}" 
+                 style="text-decoration: none; color: inherit;"
+                 target="_blank" rel="noopener">
+                ${commit.subject}
+              </a>
+            </h2>
+            
+            <div class="commit-meta" style="color: #666; font-size: 0.9rem; margin-bottom: 1rem;">
+              <span class="commit-hash" style="font-family: monospace; background: #f4f4f4; padding: 2px 6px; border-radius: 3px;">
+                ${commit.short_hash}
+              </span>
+              <span class="commit-date" style="margin-left: 1rem;">
+                ${commit.date}
+              </span>
+              <span class="commit-author" style="margin-left: 1rem;">
+                by ${commit.author_name}
+              </span>
+            </div>
+            
+            ${commit.body ? `<div class="commit-body" style="margin: 1rem 0;">${commit.body.replace(/\n/g, '<br>')}</div>` : ''}
+            
+            ${commit.changed_files_mapped && commit.changed_files_mapped.length > 0 ? `
+              <div class="commit-files" style="margin-top: 1rem;">
+                <strong>Changed files:</strong>
+                <ul style="list-style: none; padding-left: 0; margin-top: 0.5rem;">
+                  ${commit.changed_files_mapped.map(file => `
+                    <li style="margin-bottom: 0.3rem;">
+                      ${file.type === 'page' ? `
+                        <a href="${file.url}" style="text-decoration: none;">📄 ${file.file_path}</a>
+                      ` : file.type === 'section' ? `
+                        <a href="${file.url}" style="text-decoration: none;">📁 ${file.file_path}</a>
+                      ` : `
+                        <a href="${file.url}" style="text-decoration: none;" target="_blank" rel="noopener">🔗 ${file.file_path} (GitHub)</a>
+                      `}
+                    </li>
+                  `).join('')}
+                </ul>
+              </div>
+            ` : ''}
+          </article>
+        `;
+      });
       
-      {{ if $commit.changed_files_mapped }}
-        <div class="commit-files" style="margin-top: 1rem;">
-          <strong>Changed files:</strong>
-          <ul style="list-style: none; padding-left: 0; margin-top: 0.5rem;">
-            {{ range $file := $commit.changed_files_mapped }}
-              <li style="margin-bottom: 0.3rem;">
-                {{ if eq $file.type "page" }}
-                  <a href="{{ $file.url }}" style="text-decoration: none;">
-                    📄 {{ $file.file_path }}
-                  </a>
-                {{ else if eq $file.type "section" }}
-                  <a href="{{ $file.url }}" style="text-decoration: none;">
-                    📁 {{ $file.file_path }}
-                  </a>
-                {{ else }}
-                  <a href="{{ $file.url }}" style="text-decoration: none;" target="_blank" rel="noopener">
-                    🔗 {{ $file.file_path }} (GitHub)
-                  </a>
-                {{ end }}
-              </li>
-            {{ end }}
-          </ul>
-        </div>
-      {{ end }}
-    </article>
-  {{ end }}
+      container.innerHTML = html;
+      
+      // Update pagination
+      const totalPages = Math.ceil(commitsData.length / commitsPerPage);
+      document.getElementById('page-info').textContent = `Page ${currentPage} of ${totalPages}`;
+      
+      document.getElementById('prev-page').disabled = currentPage === 1;
+      document.getElementById('prev-page').style.opacity = currentPage === 1 ? '0.5' : '1';
+      
+      document.getElementById('next-page').disabled = currentPage === totalPages;
+      document.getElementById('next-page').style.opacity = currentPage === totalPages ? '0.5' : '1';
+      
+      document.getElementById('pagination-nav').style.display = totalPages > 1 ? 'block' : 'none';
+    }
+    
+    // Event listeners
+    document.getElementById('prev-page').addEventListener('click', () => {
+      if (currentPage > 1) {
+        currentPage--;
+        renderCommits();
+        window.scrollTo(0, 0);
+      }
+    });
+    
+    document.getElementById('next-page').addEventListener('click', () => {
+      const totalPages = Math.ceil(commitsData.length / commitsPerPage);
+      if (currentPage < totalPages) {
+        currentPage++;
+        renderCommits();
+        window.scrollTo(0, 0);
+      }
+    });
+    
+    // Initial render
+    renderCommits();
+  </script>
   
-  {{ if gt $totalCommits 10 }}
-    <p style="margin-top: 2rem; color: #666;">
-      Showing last 10 commits. 
-      <a href="https://github.com/ssmiller25/r15cookie-site/commits/main" target="_blank" rel="noopener">
-        View all {{ $totalCommits }} commits on GitHub →
-      </a>
-    </p>
-  {{ end }}
 {{ else }}
   <p style="color: #666; font-style: italic;">
     No commit data available. Please run <code>make generate-commits</code> to generate commit data.

--- a/layouts/index.searchindex.json
+++ b/layouts/index.searchindex.json
@@ -1,0 +1,11 @@
+[
+{{- $pages := .Site.RegularPages -}}
+{{- range $index, $page := $pages -}}
+  {{- if $index }},{{ end }}
+  {
+    "title": {{ $page.Title | jsonify }},
+    "summary": {{ $page.Summary | plainify | jsonify }},
+    "url": {{ $page.RelPermalink | jsonify }}
+  }
+{{- end -}}
+]

--- a/layouts/partials/searchbox.html
+++ b/layouts/partials/searchbox.html
@@ -1,0 +1,7 @@
+<!-- Search Box UI for Hugo site -->
+{{ if site.Params.enable_search }}
+<div id="search-container" style="margin: 1em 0;">
+  <input type="search" id="searchBox" placeholder="Search..." style="width: 100%; padding: 0.5em;">
+  <div id="searchResults" class="paper" style="margin-top: 1em; padding: 1em; border-radius: 4px; display: none;"></div>
+</div>
+{{ end }}

--- a/scripts/generate-commits-data.py
+++ b/scripts/generate-commits-data.py
@@ -86,18 +86,28 @@ def get_commits(limit: int = 100, content_only: bool = True) -> list[dict]:
         changed_files_output = run_git_command([
             "diff-tree",
             "--no-commit-id",
-            "--name-only",
+            "--name-status",
             "-r",
             full_hash
         ])
         
-        changed_files = [
-            f.strip() for f in changed_files_output.split("\n") if f.strip()
-        ]
+        # Parse name-status output: lines like "M\tfile.md" or "A\tfile.md"
+        changed_files = []
+        for line in changed_files_output.split("\n"):
+            if not line.strip():
+                continue
+            parts = line.split("\t")
+            if len(parts) >= 2:
+                status = parts[0].strip()
+                file_path = parts[1].strip()
+                changed_files.append({
+                    "path": file_path,
+                    "status": status  # A=Added, D=Deleted, M=Modified, R=Renamed
+                })
         
         # Only include commits that actually touch content/
         if content_only:
-            content_files = [f for f in changed_files if f.startswith("content/")]
+            content_files = [f for f in changed_files if f["path"].startswith("content/")]
             if not content_files:
                 continue  # Skip this commit
             changed_files = content_files  # Only show content files
@@ -111,6 +121,15 @@ def get_commits(limit: int = 100, content_only: bool = True) -> list[dict]:
             formatted_date = author_date
             iso_date = author_date
         
+        # Map status to human-readable and icon
+        status_map = {
+            "A": {"label": "Added", "icon": "➕"},
+            "D": {"label": "Deleted", "icon": "❌"},
+            "M": {"label": "Modified", "icon": "✏️"},
+            "R": {"label": "Renamed", "icon": "🔄"},
+            "C": {"label": "Copied", "icon": "📋"}
+        }
+        
         commits.append({
             "full_hash": full_hash,
             "short_hash": short_hash,
@@ -120,7 +139,8 @@ def get_commits(limit: int = 100, content_only: bool = True) -> list[dict]:
             "iso_date": iso_date,
             "subject": subject,
             "body": body,
-            "changed_files": changed_files
+            "changed_files": changed_files,
+            "status_map": status_map
         })
     
     return commits
@@ -193,10 +213,14 @@ def main():
     # Process commits and map file paths to URLs
     for commit in commits:
         mapped_files = []
-        for file_path in commit["changed_files"]:
+        for file_info in commit["changed_files"]:
+            file_path = file_info["path"]
+            status = file_info["status"]
             mapped = map_file_to_site_url(file_path, github_repo)
             if mapped:
                 mapped["file_path"] = file_path
+                mapped["status"] = status
+                mapped["status_info"] = commit["status_map"].get(status, {"label": status, "icon": "📄"})
                 mapped_files.append(mapped)
         
         commit["changed_files_mapped"] = mapped_files

--- a/scripts/generate-commits-data.py
+++ b/scripts/generate-commits-data.py
@@ -1,0 +1,214 @@
+# /// script
+# requires-python = ">=3.8"
+# dependencies = []
+# ///
+
+#!/usr/bin/env python3
+"""
+Generate commits data JSON file for Hugo site.
+Extracts git commits and formats them for use in the home page template.
+
+This script is designed to work with the r15-papercss-hugo-theme when
+it displays git commits on the home page instead of blog posts.
+
+Run with uv:
+    uv run scripts/generate-commits-data.py
+
+Configuration (in Hugo config.yaml):
+    params:
+      github_repo: "username/repo-name"  # For commit links
+
+The script will:
+1. Extract git commits (optionally filtered to content/ directory)
+2. Generate data/commits.json with commit details
+3. Map changed files to site URLs for linking
+
+Based on: https://github.com/ssmiller25/r15cookie-site
+"""
+
+import json
+import subprocess
+import sys
+from datetime import datetime
+from pathlib import Path
+
+def run_git_command(args: list[str], cwd: Path = None) -> str:
+    """Run a git command and return stdout."""
+    try:
+        result = subprocess.run(
+            ["git"] + args,
+            capture_output=True,
+            text=True,
+            check=True,
+            cwd=cwd
+        )
+        return result.stdout.strip()
+    except subprocess.CalledProcessError as e:
+        print(f"Error running git command: git {' '.join(args)}", file=sys.stderr)
+        print(f"Working directory: {cwd or Path.cwd()}", file=sys.stderr)
+        print(f"Return code: {e.returncode}", file=sys.stderr)
+        if e.stderr:
+            print(f"Git error: {e.stderr}", file=sys.stderr)
+        sys.exit(1)
+
+def get_commits(limit: int = 100, content_only: bool = True) -> list[dict]:
+    """Get recent commits with their details."""
+    format_str = "%H%n%h%n%an%n%ae%n%ai%n%s%n%b%n---COMMIT_SEPARATOR---%n"
+    
+    # Filter to only commits that touch content/ directory
+    git_args = ["log", f"-{limit}", f"--format={format_str}"]
+    if content_only:
+        git_args.append("--")  # Separator for paths
+        git_args.append("content/")  # Only commits touching content/
+    
+    log_output = run_git_command(git_args)
+    
+    commits = []
+    commit_blocks = log_output.split("---COMMIT_SEPARATOR---")
+    
+    for block in commit_blocks:
+        if not block.strip():
+            continue
+            
+        lines = block.strip().split("\n")
+        if len(lines) < 6:
+            continue
+            
+        full_hash = lines[0]
+        short_hash = lines[1]
+        author_name = lines[2]
+        author_email = lines[3]
+        author_date = lines[4]
+        subject = lines[5]
+        body = "\n".join(lines[6:]).strip() if len(lines) > 6 else ""
+        
+        # Get changed files for this commit
+        changed_files_output = run_git_command([
+            "diff-tree",
+            "--no-commit-id",
+            "--name-only",
+            "-r",
+            full_hash
+        ])
+        
+        changed_files = [
+            f.strip() for f in changed_files_output.split("\n") if f.strip()
+        ]
+        
+        # Only include commits that actually touch content/
+        if content_only:
+            content_files = [f for f in changed_files if f.startswith("content/")]
+            if not content_files:
+                continue  # Skip this commit
+            changed_files = content_files  # Only show content files
+        
+        # Parse date
+        try:
+            date_obj = datetime.fromisoformat(author_date)
+            formatted_date = date_obj.strftime("%B %d, %Y")
+            iso_date = date_obj.isoformat()
+        except:
+            formatted_date = author_date
+            iso_date = author_date
+        
+        commits.append({
+            "full_hash": full_hash,
+            "short_hash": short_hash,
+            "author_name": author_name,
+            "author_email": author_email,
+            "date": formatted_date,
+            "iso_date": iso_date,
+            "subject": subject,
+            "body": body,
+            "changed_files": changed_files
+        })
+    
+    return commits
+
+def map_file_to_site_url(file_path: str, base_url: str = "") -> dict | None:
+    """Map a git file path to a site URL."""
+    path = Path(file_path)
+    
+    if path.parts[0] == "content":
+        relative = str(path.relative_to("content"))
+        
+        if path.name == "_index.md":
+            section = str(path.parent.relative_to("content"))
+            url = f"/{section}/" if section else "/"
+            return {"url": url, "type": "section"}
+        
+        if path.suffix in [".md", ".html"]:
+            name = path.stem
+            if name == "_index":
+                name = ""
+            
+            dir_parts = list(path.parent.parts[1:])
+            if name:
+                dir_parts.append(name)
+            
+            url = "/" + "/".join(dir_parts) + "/"
+            return {"url": url, "type": "page"}
+    
+    # For non-content files, link to GitHub
+    github_repo = base_url.replace("https://github.com/", "").rstrip("/")
+    return {
+        "url": f"https://github.com/{github_repo}/blob/main/{file_path}",
+        "type": "github"
+    }
+
+def main():
+    """Generate commits data JSON file."""
+    # Get the repo root directory
+    repo_root = Path(__file__).parent.parent
+    
+    # Change to repo root directory
+    import os
+    os.chdir(repo_root)
+    
+    # Verify we're in a git repo
+    try:
+        run_git_command(["rev-parse", "--git-dir"])
+    except SystemExit:
+        print("ERROR: Not a git repository!", file=sys.stderr)
+        sys.exit(1)
+    
+    data_dir = repo_root / "data"
+    output_file = data_dir / "commits.json"
+    
+    data_dir.mkdir(exist_ok=True)
+    
+    # Get commits (filtered to content/ by default)
+    commits = get_commits(limit=100, content_only=True)
+    
+    # Get GitHub repo from config (if available)
+    github_repo = ""
+    config_file = repo_root / "config.yaml"
+    if config_file.exists():
+        with open(config_file, "r") as f:
+            for line in f:
+                if "github_repo:" in line:
+                    github_repo = line.split(":", 1)[1].strip().strip('"').strip("'")
+                    break
+    
+    # Process commits and map file paths to URLs
+    for commit in commits:
+        mapped_files = []
+        for file_path in commit["changed_files"]:
+            mapped = map_file_to_site_url(file_path, github_repo)
+            if mapped:
+                mapped["file_path"] = file_path
+                mapped_files.append(mapped)
+        
+        commit["changed_files_mapped"] = mapped_files
+    
+    # Write JSON output
+    with open(output_file, "w") as f:
+        json.dump(commits, f, indent=2)
+    
+    print(f"Generated {len(commits)} commits data at {output_file}")
+    if len(commits) == 0:
+        print("NOTE: No commits found that touch content/ directory.")
+        print("To include all commits, edit this script and set content_only=False")
+
+if __name__ == "__main__":
+    main()

--- a/static/js/search.js
+++ b/static/js/search.js
@@ -1,0 +1,59 @@
+// search.js - Fuzzy search logic for Hugo site
+// Uses Fuse.js for fuzzy searching
+
+// Load Fuse.js from CDN
+(function loadFuseJs() {
+  if (!window.Fuse) {
+    var script = document.createElement('script');
+    script.src = 'https://cdn.jsdelivr.net/npm/fuse.js@7.1.0/dist/fuse.min.js';
+    script.onload = initSearch;
+    document.head.appendChild(script);
+  } else {
+    initSearch();
+  }
+})();
+
+function initSearch() {
+  var searchInput = document.getElementById('searchBox');
+  var resultsDiv = document.getElementById('searchResults');
+  if (!searchInput || !resultsDiv) return;
+  // Hide results box initially
+  resultsDiv.style.display = 'none';
+
+  fetch('/search.json')
+    .then(response => response.json())
+    .then(data => {
+      var fuse = new Fuse(data, {
+        keys: ['title', 'summary'],
+        threshold: 0.4,
+        ignoreLocation: true,
+        minMatchCharLength: 2
+      });
+
+      searchInput.addEventListener('input', function() {
+        var query = searchInput.value.trim();
+        if (!query) {
+          resultsDiv.innerHTML = '';
+          resultsDiv.style.display = 'none';
+          return;
+        }
+        var results = fuse.search(query);
+        resultsDiv.style.display = 'block';
+        if (results.length === 0) {
+          resultsDiv.innerHTML = '<p>No results found.</p>';
+          return;
+        }
+        resultsDiv.innerHTML = results.map(function(result) {
+          var item = result.item;
+          return '<div class="search-result">' +
+            '<a href="' + item.url + '"><strong>' + item.title + '</strong></a><br>' +
+            '<span>' + item.summary + '</span>' +
+            '</div>';
+        }).join('');
+      });
+    })
+    .catch(function(err) {
+      resultsDiv.style.display = 'block';
+      resultsDiv.innerHTML = '<p>Error loading search index.</p>';
+    });
+}

--- a/static/js/search.js
+++ b/static/js/search.js
@@ -39,17 +39,32 @@ function initSearch() {
         }
         var results = fuse.search(query);
         resultsDiv.style.display = 'block';
+        resultsDiv.innerHTML = '';
         if (results.length === 0) {
-          resultsDiv.innerHTML = '<p>No results found.</p>';
+          var empty = document.createElement('p');
+          empty.textContent = 'No results found.';
+          resultsDiv.appendChild(empty);
           return;
         }
-        resultsDiv.innerHTML = results.map(function(result) {
+        results.forEach(function(result) {
           var item = result.item;
-          return '<div class="search-result">' +
-            '<a href="' + item.url + '"><strong>' + item.title + '</strong></a><br>' +
-            '<span>' + item.summary + '</span>' +
-            '</div>';
-        }).join('');
+          var entry = document.createElement('div');
+          entry.className = 'search-result';
+
+          var link = document.createElement('a');
+          link.href = item.url;
+          var strong = document.createElement('strong');
+          strong.textContent = item.title;
+          link.appendChild(strong);
+
+          var summary = document.createElement('span');
+          summary.textContent = item.summary;
+
+          entry.appendChild(link);
+          entry.appendChild(document.createElement('br'));
+          entry.appendChild(summary);
+          resultsDiv.appendChild(entry);
+        });
       });
     })
     .catch(function(err) {


### PR DESCRIPTION
## Summary
Update the home page template to display git commits instead of blog posts. This allows the blog to showcase site changes directly from git history.

## Changes
- Replace blog post listing with git commits listing
- Read commit data from `data/commits.json` (generated by pre-build script)
- Display commit subject, body, hash, date, and author
- Link to changed files (rendered pages for content, GitHub for other files)
- Show last 10 commits with link to GitHub for full history

## Testing
1. Ensure `data/commits.json` exists in the Hugo site
2. Build the site with Hugo
3. Home page should display commits instead of blog posts

## Dependent PR
Requires r15cookie-site PR: https://github.com/ssmiller25/r15cookie-site/pull/7