### PR TITLE
docs: make notes-push/notes-sync requirement explicit in make help

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,17 +12,17 @@ build-example:   ## Build the example site
 	@(cd exampleSite; hugo --themesDir ../..; cd ..)
 
 .PHONY: note
-note:   ## Add/edit a display-override note for a commit: make note HASH=<commit-hash>
+note:   ## Add/edit a display-override note: make note HASH=<hash> (local only - git push does NOT push notes, run notes-push after)
 	@test -n "$(HASH)" || (echo "Usage: make note HASH=<commit-hash>"; exit 1)
 	@git notes --ref=$(NOTES_REF) edit $(HASH)
 	@echo "Note saved locally. Run 'make notes-push' to publish it."
 
 .PHONY: notes-push
-notes-push:   ## Publish local display-override notes to origin
+notes-push:   ## Push refs/notes/site-display to origin (required after 'make note' - not included in a normal git push)
 	@git push origin $(NOTES_REF)
 
 .PHONY: notes-sync
-notes-sync:   ## Fetch display-override notes from origin
+notes-sync:   ## Pull refs/notes/site-display from origin (not included in a normal git fetch/pull/clone)
 	@git fetch origin $(NOTES_REF):$(NOTES_REF)
 
 # Help Source: https://gist.github.com/prwhite/8168133


### PR DESCRIPTION
## Summary
Follow-up to #7. git notes under `refs/notes/site-display` aren't included in a normal `git push`/`fetch`/`clone` — you have to publish/pull them explicitly via `make notes-push`/`make notes-sync`. That wasn't obvious from the target names alone, so this makes it explicit in `make help` output.

This repo has no `AGENTS.md`, so `make help` is the main place to document this for an agent or a human skimming quickly. (r15cookie-site and recipe got the equivalent `AGENTS.md` treatment in their own open PRs, since they have that file.)

## Changes
- `Makefile`: reworded the `note`, `notes-push`, and `notes-sync` help comments to spell out that notes aren't pushed/fetched automatically

## Testing
- `make help` output reviewed for clarity
- Verified Makefile still parses correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)